### PR TITLE
Fix Vercel deployment configuration

### DIFF
--- a/cosqol-dashboard/package.json
+++ b/cosqol-dashboard/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@angular/build": "^20.3.1",
-    "@angular/cli": "^20.3.1",
+    "@angular/cli": "20.3.1",
     "@angular/compiler-cli": "^20.3.0",
     "@types/jasmine": "~5.1.0",
     "jasmine-core": "~5.9.0",

--- a/cosqol-dashboard/vercel.json
+++ b/cosqol-dashboard/vercel.json
@@ -1,0 +1,8 @@
+{
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@vercel/angular"
+    }
+  ]
+}


### PR DESCRIPTION
This commit addresses several issues to ensure the application deploys correctly on Vercel.

- Creates `cosqol-dashboard/vercel.json` and configures it for an Angular application. This file is placed in the project root as specified.
- Ensures the Node.js version is set to 18.x in `cosqol-dashboard/package.json`.
- Locks the Angular CLI dependency to the latest version (`20.3.1`) in `devDependencies`.