### PR TITLE
Fix Vercel 404 Not Found error

### DIFF
--- a/cosqol-dashboard/angular.json
+++ b/cosqol-dashboard/angular.json
@@ -24,6 +24,7 @@
         "build": {
           "builder": "@angular/build:application",
           "options": {
+            "outputPath": "dist",
             "browser": "src/main.ts",
             "polyfills": [
               "zone.js"

--- a/cosqol-dashboard/vercel.json
+++ b/cosqol-dashboard/vercel.json
@@ -4,5 +4,8 @@
       "src": "package.json",
       "use": "@vercel/angular"
     }
+  ],
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
This change fixes the 404 Not Found error when deploying the Angular application to Vercel.

The issue was caused by a misconfiguration of the Vercel deployment for a Single Page Application (SPA).

The following changes were made:
- In `angular.json`, the `outputPath` is now explicitly set to `dist`. This ensures that the build artifacts are placed in a location that the `@vercel/angular` preset expects.
- In `vercel.json`, a `rewrites` rule has been added to redirect all non-file requests to `index.html`. This is necessary for the Angular router to handle client-side routing correctly.