### PR TITLE
fix: specify output directory in vercel.json

### DIFF
--- a/cosqol-dashboard/vercel.json
+++ b/cosqol-dashboard/vercel.json
@@ -2,7 +2,10 @@
   "builds": [
     {
       "src": "package.json",
-      "use": "@vercel/angular"
+      "use": "@vercel/angular",
+      "options": {
+        "outputDirectory": "dist"
+      }
     }
   ],
   "rewrites": [


### PR DESCRIPTION
The Vercel deployment was failing because the build output was not being correctly identified. The Angular project is configured to build to the `dist` directory, but the `@vercel/angular` builder was not picking this up automatically.

This change explicitly sets the `outputDirectory` to `dist` in `vercel.json` to ensure Vercel can find and deploy the built application.