### PR TITLE
Fix Vercel deployment and resolve critical build errors

### DIFF
--- a/cosqol-dashboard/angular.json
+++ b/cosqol-dashboard/angular.json
@@ -24,7 +24,7 @@
         "build": {
           "builder": "@angular/build:application",
           "options": {
-            "outputPath": "dist",
+            "outputPath": "dist/cosqol-dashboard",
             "browser": "src/main.ts",
             "polyfills": [
               "zone.js"

--- a/cosqol-dashboard/package-lock.json
+++ b/cosqol-dashboard/package-lock.json
@@ -14,13 +14,14 @@
         "@angular/forms": "^20.3.0",
         "@angular/platform-browser": "^20.3.0",
         "@angular/router": "^20.3.0",
+        "chart.js": "^4.5.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.15.0"
       },
       "devDependencies": {
         "@angular/build": "^20.3.1",
-        "@angular/cli": "^20.3.1",
+        "@angular/cli": "20.3.1",
         "@angular/compiler-cli": "^20.3.0",
         "@types/jasmine": "~5.1.0",
         "jasmine-core": "~5.9.0",
@@ -1873,6 +1874,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
     },
     "node_modules/@listr2/prompt-adapter-inquirer": {
       "version": "3.0.1",
@@ -4388,6 +4395,18 @@
       "integrity": "sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
     },
     "node_modules/chokidar": {
       "version": "4.0.3",

--- a/cosqol-dashboard/package.json
+++ b/cosqol-dashboard/package.json
@@ -31,6 +31,7 @@
     "@angular/forms": "^20.3.0",
     "@angular/platform-browser": "^20.3.0",
     "@angular/router": "^20.3.0",
+    "chart.js": "^4.5.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.0"

--- a/cosqol-dashboard/src/app/app.module.ts
+++ b/cosqol-dashboard/src/app/app.module.ts
@@ -8,15 +8,14 @@ import { Sidebar } from './layout/sidebar/sidebar';
 import { Header } from './layout/header/header';
 
 @NgModule({
-  declarations: [
+  declarations: [],
+  imports: [
+    BrowserModule,
+    AppRoutingModule,
     App,
     MainLayout,
     Sidebar,
     Header
-  ],
-  imports: [
-    BrowserModule,
-    AppRoutingModule
   ],
   providers: [
     provideBrowserGlobalErrorListeners()

--- a/cosqol-dashboard/src/app/app.ts
+++ b/cosqol-dashboard/src/app/app.ts
@@ -1,7 +1,10 @@
 import { Component } from '@angular/core';
+import { RouterModule } from '@angular/router';
 
 @Component({
   selector: 'app-root',
+  standalone: true,
+  imports: [RouterModule],
   templateUrl: './app.html',
   styleUrl: './app.scss'
 })

--- a/cosqol-dashboard/src/app/features/dashboard/dashboard.module.ts
+++ b/cosqol-dashboard/src/app/features/dashboard/dashboard.module.ts
@@ -6,12 +6,11 @@ import { Overview } from './pages/overview/overview';
 
 
 @NgModule({
-  declarations: [
-    Overview
-  ],
+  declarations: [],
   imports: [
     CommonModule,
-    DashboardRoutingModule
+    DashboardRoutingModule,
+    Overview
   ]
 })
 export class DashboardModule { }

--- a/cosqol-dashboard/src/app/features/dashboard/pages/overview/overview.ts
+++ b/cosqol-dashboard/src/app/features/dashboard/pages/overview/overview.ts
@@ -3,6 +3,7 @@ import Chart from 'chart.js/auto';
 
 @Component({
   selector: 'app-overview',
+  standalone: true,
   templateUrl: './overview.html',
   styleUrls: ['./overview.scss']
 })
@@ -35,7 +36,7 @@ export class Overview implements AfterViewInit {
             scales: {
                 y: {
                     beginAtZero: true,
-                    ticks: { callback: function(value) { return value + 's'; } }
+                    ticks: { callback: function(value: string | number) { return value + 's'; } }
                 },
                 x: { grid: { display: false } }
             }

--- a/cosqol-dashboard/src/app/layout/header/header.ts
+++ b/cosqol-dashboard/src/app/layout/header/header.ts
@@ -4,6 +4,7 @@ import { filter, map } from 'rxjs/operators';
 
 @Component({
   selector: 'app-header',
+  standalone: true,
   templateUrl: './header.html',
   styleUrls: ['./header.scss']
 })

--- a/cosqol-dashboard/src/app/layout/main-layout/main-layout.ts
+++ b/cosqol-dashboard/src/app/layout/main-layout/main-layout.ts
@@ -1,7 +1,12 @@
 import { Component } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { Sidebar } from '../sidebar/sidebar';
+import { Header } from '../header/header';
 
 @Component({
   selector: 'app-main-layout',
+  standalone: true,
+  imports: [RouterModule, Sidebar, Header],
   templateUrl: './main-layout.html',
   styleUrls: ['./main-layout.scss']
 })

--- a/cosqol-dashboard/src/app/layout/sidebar/sidebar.ts
+++ b/cosqol-dashboard/src/app/layout/sidebar/sidebar.ts
@@ -1,7 +1,10 @@
 import { Component, EventEmitter, Output } from '@angular/core';
+import { RouterModule } from '@angular/router';
 
 @Component({
   selector: 'app-sidebar',
+  standalone: true,
+  imports: [RouterModule],
   templateUrl: './sidebar.html',
   styleUrls: ['./sidebar.scss']
 })

--- a/cosqol-dashboard/vercel.json
+++ b/cosqol-dashboard/vercel.json
@@ -3,12 +3,12 @@
     {
       "src": "package.json",
       "use": "@vercel/angular",
-      "options": {
-        "outputDirectory": "dist"
+      "config": {
+        "distDir": "dist/cosqol-dashboard/browser"
       }
     }
   ],
-  "rewrites": [
-    { "source": "/(.*)", "destination": "/index.html" }
+  "routes": [
+    { "src": "/.*", "dest": "/index.html" }
   ]
 }


### PR DESCRIPTION
This commit addresses a Vercel deployment failure caused by an incorrect `distDir` configuration.

It also resolves a series of critical build errors that were discovered during the investigation. The application was in a broken state due to an incomplete migration to Angular standalone components.

Changes include:
- Corrected the `outputPath` in `angular.json` to `dist/cosqol-dashboard`.
- Updated `vercel.json` to point to the correct build output directory (`dist/cosqol-dashboard/browser`).
- Completed the migration to standalone components for `App`, `MainLayout`, `Sidebar`, `Header`, and `Overview`.
- Installed the missing `chart.js` dependency.
- Fixed a TypeScript type error in the chart configuration.

These changes restore the application to a buildable state and ensure it can be deployed correctly on Vercel.