### PR TITLE
Fix Vercel routing for Angular app

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -8,7 +8,7 @@
       }
     }
   ],
-  "routes": [
-    { "src": "/(.*)", "dest": "/index.html" }
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
Updated vercel.json to use rewrites instead of routes to handle client-side routing for the Angular application. This will prevent 404 errors when navigating to routes other than the root.